### PR TITLE
Overflows and offsets aka "glitches" fixes

### DIFF
--- a/src/components/molecules/Gallery.js
+++ b/src/components/molecules/Gallery.js
@@ -10,6 +10,7 @@ const Holder = styled.div`
   position: relative;
   width: 100%;
   -webkit-overflow-scrolling: touch;
+  padding-top: 54px;
   background-color: ${props => props.theme.colors.white};
 
   &.absPositioned {

--- a/src/components/organisms/WorkNav/WorkNav.js
+++ b/src/components/organisms/WorkNav/WorkNav.js
@@ -21,7 +21,7 @@ const Container = styled.div`
   .work-nav-container {
     position: relative;
     overflow-x: hidden;
-    overflow-y: ${({$active}) => ($active ? "scroll" : "hidden")};
+    overflow-y: scroll;
     height: 100%;
   }
 `;

--- a/src/components/organisms/WorkNav/WorkNavLink.js
+++ b/src/components/organisms/WorkNav/WorkNavLink.js
@@ -125,15 +125,20 @@ const WorkNavLink = (props) => {
     const el = props.workNavRef?.current.querySelector(`#work-${props.work.id}`);
     if (!el) return;
 
-    const {top, bottom} = el?.getBoundingClientRect();
 
+    const {top, bottom} = el?.getBoundingClientRect();
+  
     const windowHeight = window?.innerHeight;
 
-    const up = -bottom + 48;
+    const up = -bottom + 56;
     const down = windowHeight - top;
 
     setWorkNavUpPosition(up);
     setWorkNavDownPosition(down);
+
+    setTimeout(() => {
+      console.log('timeout bottom', el?.getBoundingClientRect()?.bottom);
+    }, 1500)
   };
 
   const handleNavigate = () => {

--- a/src/hooks/useInitialWorkNavSplit.js
+++ b/src/hooks/useInitialWorkNavSplit.js
@@ -23,8 +23,8 @@ export default function useInitialWorkNavSplit(workNavRef, id, index) {
       const split = setTimeout(() => {
         // 3. Calculate translate distance for nav up and down
         const windowHeight = window?.innerHeight;
-        let up = -(height - 48);
-        const down = windowHeight - 48;
+        let up = -(height - 56);
+        const down = windowHeight - 56;
         // 4. Set nav split index to work link
         // 5. Set nav up and down position
         setWorkNavSplitIndex(index);

--- a/src/templates/WorkTemplate.js
+++ b/src/templates/WorkTemplate.js
@@ -14,7 +14,7 @@ import {useStore} from "../utils/store";
 const Container = styled.div`
   position: relative;
   min-height: var(--windowHeight);
-  margin-top: 100px;
+  padding: 56px 0 48px;
   background-color: ${({theme}) => theme.colors.white};
 `;
 

--- a/src/templates/WorkTemplate.js
+++ b/src/templates/WorkTemplate.js
@@ -24,7 +24,7 @@ max-height: var(--windowHeight);
     padding: 0 24px;
   }
 
-  overflow: scroll;
+  overflow-y: scroll;
 `;
 const TextHolder = styled.div`
   display: grid;

--- a/src/templates/WorkTemplate.js
+++ b/src/templates/WorkTemplate.js
@@ -11,18 +11,20 @@ import StackedImages from "../components/molecules/StackedImages";
 
 const Container = styled.div`
   position: relative;
-  min-height: calc(100vh - 48px);
-  margin-top: 48px;
+  min-height: var(--windowHeight);
+  margin-top: 100px;
   background-color: ${({theme}) => theme.colors.white};
 `;
 
 const Content = styled.div`
+max-height: var(--windowHeight);
+
   padding: 0 15px;
   @media (${props => props.theme.breakpoints.sm}) {
     padding: 0 24px;
   }
 
-  overflow: hidden;
+  overflow: scroll;
 `;
 const TextHolder = styled.div`
   display: grid;


### PR DESCRIPTION
- Added max height-and overflow-y: scroll to WorkTemplate Content. Think this fixes the thumbnails peeking beneath the open Gallery Slides. Smile Makers is a good project to check on. Also Handsome.

- Also, increased margin-top to the WorkTemplate Container to arbitrary larger value. Needs something more precise but not sure how to calculate it/ measure/ understand what is changing to make it hidden in some cases at margin-top: 48px.

- There is now though some annoying stuff going on with (I think) overflow-y: scroll of different divs (WorkTemplateContainer and WorkTemplateContent) which is causing some issue where you can't scroll unless you move your cursor to the other Container at various points...