### PR TITLE
Fix for footer gap due to custom kerning requirements

### DIFF
--- a/src/components/atoms/GlobalStyles.js
+++ b/src/components/atoms/GlobalStyles.js
@@ -16,7 +16,7 @@ const GlobalStyle = createGlobalStyle`
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     ${props => props.theme.fluidType(0)};
-    overscroll-behavior-y: none;
+    overscroll-behavior: none;
 
     * { box-sizing: border-box; }
   }
@@ -27,7 +27,7 @@ const GlobalStyle = createGlobalStyle`
     font-family: "Adineue PRO Black", "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
     color: ${props => props.theme.colors.black};
     background-color: ${props => props.theme.colors.white};
-    overscroll-behavior-y: none;
+    overscroll-behavior: none;
   }
 
   h1, h2, h3, h4, h5, h6,

--- a/src/components/atoms/GlobalStyles.js
+++ b/src/components/atoms/GlobalStyles.js
@@ -58,7 +58,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   h1, .h1, .h1.button {
-    font-size: 35vw;
+    font-size: 33.5vw;
     font-kerning: normal;
     text-transform: uppercase;
     letter-spacing: -0.025em;

--- a/src/components/molecules/Header.js
+++ b/src/components/molecules/Header.js
@@ -11,13 +11,13 @@ const Holder = styled.div`
   align-items: center;
   background-color: ${({theme}) => theme.colors.white};
   @media (${props => props.theme.breakpoints.md}) {
-    padding: 24px 24px 0 24px;
+    padding: 24px 24px 24px 24px;
     grid-template-columns: 1fr 1fr;
   }
   &.bottom {
     padding: 0 12px 12px 12px;
     @media (${props => props.theme.breakpoints.md}) {
-      padding: 0 24px 24px 24px;
+      padding: 12px 24px 24px 24px;
     }
   }
 

--- a/src/components/organisms/GlobalNav/GlobalNavLinkHolder.js
+++ b/src/components/organisms/GlobalNav/GlobalNavLinkHolder.js
@@ -5,34 +5,36 @@ import {motion} from "framer-motion";
 import {useStore} from "../../../utils/store";
 
 const Holder = styled.div`
-  position: relative;
-  width: 100%;
-  display: block;
-  background-color: ${({theme}) => theme.colors.white};
-  z-index: 1;
-  will-change: transform;
+    position: relative;
+    width: 100%;
+    display: block;
+    background-color: ${({theme}) => theme.colors.white};
+    //background-color: rgba(255, 0, 0, 0.5);
+    z-index: 1;
+    margin-top: -1px;
+    will-change: transform;
 `;
 const Border = styled.div`
-  position: absolute;
-  top: calc(100% - 1px);
-  left: 0;
-  width: 100%;
-  height: 1px;
-  background-color: black;
-  transform-origin: right;
-  will-change: transform;
+    position: absolute;
+    top: calc(100% - 1px);
+    left: 0;
+    width: 100%;
+    height: 1px;
+    background-color: black;
+    transform-origin: right;
+    will-change: transform;
 `;
 
 const Close = styled.button`
-  position: absolute;
-  top: calc(100% - 48px);
-  z-index: 10;
-  left: 0;
-  width: 100%;
-  height: 48px;
-  background: transparent !important;
-  pointer-events: auto;
-  opacity: 0.2;
+    position: absolute;
+    top: calc(100% - 48px);
+    z-index: 10;
+    left: 0;
+    width: 100%;
+    height: 48px;
+    background: transparent !important;
+    pointer-events: auto;
+    opacity: 0.2;
 `;
 
 const Inner = styled.div`


### PR DESCRIPTION
The reason this fix is needed is that the custom kerning requirements that translate individual letters up and down by certain percentages create a space at the foot of the container. This gap is filled to a certain extent by the footer, however on larger screens this this gap increases as the font size is linked to the screenwidth for the large text. We can not simply put overflow hidden on the container as this cuts off the text when we hover on the right of the screen. This need for both custom kerning AND hover right means we are stuck doing something a little fiddly to fix this (and many other things). 

SO. I have slightly decreased the font size on all the text (I think this as low as we can go without discussing with BMEOF) and adding a tiny bit of padding on the top of the footer.

This will need to be checked on a few devices and browsers to make sure I have completely covered the gap. Please check on mobile as well. I do not want to launch something half fixed as we have done that a few times recently and it is probably going to start annoying the client at some point. 

There is a possibility that if this doesn't cover enough and the gap appears on larger screens then you could make padding top on the footer a vw unit.

When you do merge and show BMEOF can you tell them (in simplified terms) what we have done and check he is OK with that.